### PR TITLE
Feat(#11): ErrorLog 저장 및 최종 ErrorHandling 로직 구현

### DIFF
--- a/app/src/main/java/com/example/errorhandlingex/di/AppResourceProvider.kt
+++ b/app/src/main/java/com/example/errorhandlingex/di/AppResourceProvider.kt
@@ -1,0 +1,16 @@
+package com.example.errorhandlingex.di
+
+import android.content.Context
+import com.example.presentation.util.ResourceProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AppResourceProvider @Inject constructor(
+    @ApplicationContext private val context: Context
+) : ResourceProvider {
+    override fun getString(resId: Int): String {
+        return context.getString(resId)
+    }
+}

--- a/app/src/main/java/com/example/errorhandlingex/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/errorhandlingex/di/RepositoryModule.kt
@@ -1,6 +1,8 @@
-package com.example.todayfortunebytdd.di
+package com.example.errorhandlingex.di
 
+import com.example.data.repositoryImpl.ErrorLogRepositoryImpl
 import com.example.data.repositoryImpl.TotalInfoRepositoryImpl
+import com.example.domain.repository.ErrorLogRepository
 import com.example.domain.repository.TotalInfoRepository
 import dagger.Binds
 import dagger.Module
@@ -12,4 +14,7 @@ import dagger.hilt.components.SingletonComponent
 abstract class RepositoryModule {
     @Binds
     abstract fun totalInfoRepository(repositoryImpl: TotalInfoRepositoryImpl): TotalInfoRepository
+
+    @Binds
+    abstract fun errorLogRepository(repositoryImpl: ErrorLogRepositoryImpl): ErrorLogRepository
 }

--- a/app/src/main/java/com/example/errorhandlingex/di/ResourceModule.kt
+++ b/app/src/main/java/com/example/errorhandlingex/di/ResourceModule.kt
@@ -1,0 +1,14 @@
+package com.example.errorhandlingex.di
+
+import com.example.presentation.util.ResourceProvider
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ResourceModule {
+    @Binds
+    abstract fun bindResourceProvider(impl: AppResourceProvider): ResourceProvider
+}

--- a/app/src/main/java/com/example/errorhandlingex/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/errorhandlingex/di/UseCaseModule.kt
@@ -1,8 +1,10 @@
 package com.example.todayfortunebytdd.di
 
+import com.example.domain.repository.ErrorLogRepository
 import com.example.domain.repository.TotalInfoRepository
 import com.example.domain.usecase.FetchTotalInfoUseCase
 import com.example.domain.usecase.GetTotalInfoUseCase
+import com.example.domain.usecase.SaveErrorLogUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -23,5 +25,12 @@ object UseCaseModule {
         totalInfoRepository: TotalInfoRepository
     ): FetchTotalInfoUseCase {
         return FetchTotalInfoUseCase(totalInfoRepository)
+    }
+
+    @Provides
+    fun saveErrorLog(
+        saveErrorLogRepository: ErrorLogRepository
+    ): SaveErrorLogUseCase {
+        return SaveErrorLogUseCase(saveErrorLogRepository)
     }
 }

--- a/data/src/main/java/com/example/data/mapper/ErrorLogMapper.kt
+++ b/data/src/main/java/com/example/data/mapper/ErrorLogMapper.kt
@@ -1,0 +1,36 @@
+package com.example.data.mapper
+
+import android.os.Build
+import androidx.annotation.RequiresExtension
+import com.example.data.room.entity.ErrorLogEntity
+import com.example.domain.model.ErrorLogData
+import com.example.domain.model.Failure
+import retrofit2.HttpException
+
+// failure <-> entity
+object ErrorLogMapper {
+    @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
+    fun mapperToErrorLogEntity(failure: Failure): ErrorLogEntity {
+        return if (failure.e?.cause is HttpException) {
+            val error = failure.e?.cause as HttpException
+            ErrorLogEntity(
+                id = 0,
+                code = error.code(),
+                message = failure.message ?: "알 수 없는 오류"
+            )
+        } else {
+            ErrorLogEntity(
+                id = 0,
+                code = -1,
+                message = failure.message ?: "알 수 없는 오류"
+            )
+        }
+    }
+
+    fun mapperToErrorLogData(errorLogEntity: ErrorLogEntity): ErrorLogData {
+        return ErrorLogData(
+            code = errorLogEntity.code,
+            message = errorLogEntity.message
+        )
+    }
+}

--- a/data/src/main/java/com/example/data/repositoryImpl/ErrorLogRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repositoryImpl/ErrorLogRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package com.example.data.repositoryImpl
+
+import android.os.Build
+import androidx.annotation.RequiresExtension
+import com.example.data.exception.DataException
+import com.example.data.exception.DataException.Companion.toFailure
+import com.example.data.mapper.ErrorLogMapper
+import com.example.data.room.TodayFortuneDb
+import com.example.domain.model.Failure
+import com.example.domain.repository.ErrorLogRepository
+import javax.inject.Inject
+
+class ErrorLogRepositoryImpl @Inject constructor(
+    private val todayFortuneDb: TodayFortuneDb
+) : ErrorLogRepository {
+    @RequiresExtension(extension = Build.VERSION_CODES.S, version = 7)
+    override suspend fun saveErrorLog(failure: Failure) {
+        try {
+            val errorLogEntity = ErrorLogMapper.mapperToErrorLogEntity(failure)
+            todayFortuneDb.dao().insertErrorLog(errorLogEntity)
+        } catch (e: Exception) {
+            DataException.mapToDataException(e).toFailure()
+        }
+    }
+}

--- a/data/src/main/java/com/example/data/room/TodayFortuneDao.kt
+++ b/data/src/main/java/com/example/data/room/TodayFortuneDao.kt
@@ -4,6 +4,8 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import com.example.data.room.entity.ErrorLogEntity
+import com.example.data.room.entity.TotalInfoEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -15,4 +17,8 @@ interface TodayFortuneDao {
     // totalInfo DB에 저장
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertTotalInfo(totalInfo: TotalInfoEntity)
+
+    // errorLog DB에 저장
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertErrorLog(errorLog: ErrorLogEntity)
 }

--- a/data/src/main/java/com/example/data/room/TodayFortuneDb.kt
+++ b/data/src/main/java/com/example/data/room/TodayFortuneDb.kt
@@ -2,10 +2,12 @@ package com.example.data.room
 
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import com.example.data.room.entity.ErrorLogEntity
+import com.example.data.room.entity.TotalInfoEntity
 
 @Database(
-    entities = [TotalInfoEntity::class],
-    version = 1
+    entities = [TotalInfoEntity::class, ErrorLogEntity::class],
+    version = 2
 )
 abstract class TodayFortuneDb : RoomDatabase() {
     abstract fun dao(): TodayFortuneDao

--- a/domain/src/main/java/com/example/domain/model/Failure.kt
+++ b/domain/src/main/java/com/example/domain/model/Failure.kt
@@ -4,12 +4,12 @@ sealed class Failure(
     val message: String?,
     val e: Throwable? = null
 ) {
-    // ValidationFailure, UiWarningFailure는 ErrorLog 저장 X
+    // ValidationFailure, UiWarningFailure, BusinessFailure는 ErrorLog 저장 X
     class NetworkFailure(e: Throwable? = null) : Failure(e?.message ?: "네트워크 오류", e)
     class ServerFailure(e: Throwable? = null) : Failure(e?.message ?: "서버 오류", e)
     class DatabaseFailure(e: Throwable? = null) : Failure(e?.message ?: "DB 오류", e)
     class BusinessFailure(e: Throwable? = null) : Failure(e?.message ?: "비즈니스 로직 오류", e)
-    class ValidationFailure(message: String? = "잘못된 입력값입니다. 올바른 값을 입력해 주세요", e: Throwable? = null) : Failure(e?.message ?: message, e)
+    class ValidationFailure(message: String?, e: Throwable? = null) : Failure(message ?: e?.message, e)
     class UiErrorFailure(e: Throwable? = null) : Failure(e?.message, e)
     class UiWarningFailure(e: Throwable? = null) : Failure(e?.message, e)
     class AppCrashFailure(e: Throwable? = null) : Failure(e?.message ?: "치명적 오류", e)

--- a/domain/src/main/java/com/example/domain/repository/ErrorLogRepository.kt
+++ b/domain/src/main/java/com/example/domain/repository/ErrorLogRepository.kt
@@ -1,0 +1,9 @@
+package com.example.domain.repository
+
+import com.example.domain.model.Failure
+
+
+interface ErrorLogRepository {
+    // DB에 ErrorLog 저장
+    suspend fun saveErrorLog(failure: Failure)
+}

--- a/domain/src/main/java/com/example/domain/usecase/SaveErrorLogUseCase.kt
+++ b/domain/src/main/java/com/example/domain/usecase/SaveErrorLogUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.domain.usecase
+
+import com.example.domain.model.Failure
+import com.example.domain.repository.ErrorLogRepository
+
+class SaveErrorLogUseCase(
+    private val errorLogRepository: ErrorLogRepository
+) {
+    suspend operator fun invoke(failure: Failure) {
+        return errorLogRepository.saveErrorLog(failure)
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/MainHomeViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/MainHomeViewModel.kt
@@ -1,11 +1,12 @@
 package com.example.presentation
 
-import androidx.lifecycle.ViewModel
+import android.content.Context
 import com.example.domain.model.Failure
 import com.example.domain.model.ResultWrapper
 import com.example.domain.model.TotalInfoData
 import com.example.domain.usecase.FetchTotalInfoUseCase
 import com.example.domain.usecase.GetTotalInfoUseCase
+import com.example.presentation.base.BaseViewModel
 import com.example.presentation.state.UiState
 import com.example.presentation.util.TextValidator
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +18,7 @@ import javax.inject.Inject
 class MainHomeViewModel @Inject constructor(
     private val getTotalInfoUseCase: GetTotalInfoUseCase,
     private val fetchTotalInfoUseCase: FetchTotalInfoUseCase
-) : ViewModel() {
+) : BaseViewModel() {
     private val _mainHomeUiState =
         MutableStateFlow<UiState<MainHomeUiState>>(UiState.Success(MainHomeUiState()))
     val mainHomeUiState = _mainHomeUiState.asStateFlow()
@@ -64,14 +65,8 @@ class MainHomeViewModel @Inject constructor(
         }
     }
 
-    private fun mapFailureToUiState(failure: Failure): UiState.Error<MainHomeUiState> {
-        val errorMessage = when (failure) {
-            is Failure.NetworkFailure -> "네트워크 연결이 불안정합니다. 연결을 확인해 주세요."
-            is Failure.ServerFailure -> "서버에서 오류가 발생했습니다. 잠시 후 다시 시도해 주세요."
-            is Failure.DatabaseFailure, is Failure.FileIOFailure -> "데이터를 불러오지 못했습니다. 다시 시도해 주세요."
-            is Failure.ValidationFailure, is Failure.BusinessFailure -> "입력값이 잘못되었습니다. 다시 입력해 주세요."
-            is Failure.UnknownFailure -> failure.message
-        }
+    suspend fun mapFailureToUiState(failure: Failure): UiState.Error<MainHomeUiState> {
+        val errorMessage = handleFailure(failure)
 
         val errorState = initialState.copy(
             isUsernameClear = false,

--- a/presentation/src/main/java/com/example/presentation/base/BaseViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/base/BaseViewModel.kt
@@ -1,0 +1,44 @@
+package com.example.presentation.base
+
+import androidx.lifecycle.ViewModel
+import com.example.domain.model.Failure
+import com.example.domain.usecase.SaveErrorLogUseCase
+import com.example.presentation.R
+import com.example.presentation.util.ResourceProvider
+import javax.inject.Inject
+
+abstract class BaseViewModel : ViewModel() {
+    @Inject
+    lateinit var resourceProvider: ResourceProvider
+
+    @Inject
+    lateinit var saveErrorLogUseCase: SaveErrorLogUseCase
+
+    open suspend fun handleFailure(failure: Failure): String? {
+        // 에러 메세지 반환
+        val errorMessage = when (failure) {
+            is Failure.NetworkFailure -> resourceProvider.getString(R.string.error_message_network_failure)
+            is Failure.ServerFailure -> resourceProvider.getString(R.string.error_message_server_failure)
+            is Failure.DatabaseFailure -> resourceProvider.getString(R.string.error_message_database_failure)
+            is Failure.ValidationFailure -> failure.message
+                ?: resourceProvider.getString(R.string.error_message_validation_failure)
+
+            is Failure.BusinessFailure -> failure.message
+                ?: resourceProvider.getString(R.string.error_message_business_failure)
+
+            is Failure.AppCrashFailure -> failure.message
+                ?: resourceProvider.getString(R.string.error_message_app_crash_failure)
+
+            is Failure.UiErrorFailure -> failure.message
+            is Failure.UiWarningFailure -> failure.message
+            is Failure.UnknownFailure -> resourceProvider.getString(R.string.error_message_unknown_failure)
+        }
+
+        // 에러 로그 저장
+        if (!(failure is Failure.ValidationFailure || failure is Failure.UiWarningFailure || failure is Failure.BusinessFailure)) {
+            saveErrorLogUseCase.invoke(failure)
+        }
+
+        return errorMessage
+    }
+}

--- a/presentation/src/main/java/com/example/presentation/exception/ErrorHandlingActivity.kt
+++ b/presentation/src/main/java/com/example/presentation/exception/ErrorHandlingActivity.kt
@@ -1,4 +1,4 @@
-package com.example.presentation.error
+package com.example.presentation.exception
 
 import android.content.Intent
 import android.os.Bundle

--- a/presentation/src/main/java/com/example/presentation/exception/UiException.kt
+++ b/presentation/src/main/java/com/example/presentation/exception/UiException.kt
@@ -1,7 +1,9 @@
 package com.example.presentation.exception
 
+import android.content.Context
 import android.hardware.camera2.CameraAccessException
 import com.example.domain.model.Failure
+import com.example.presentation.R
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.nio.BufferOverflowException
@@ -19,33 +21,33 @@ sealed class UiException(alert: String?, cause: Throwable? = null) : Exception(a
     class UnknownError(alert: String, cause: Throwable? = null) : UiException(alert, cause)
 
     companion object {
-        fun mapToUiException(e: Throwable): UiException {
+        fun mapToUiException(e: Throwable, context: Context): UiException {
             return when (e) {
                 is IllegalStateException, is NullPointerException, is IllegalArgumentException ->
-                    UiStateError("예상치 못한 오류가 발생했습니다. 새로고침을 시도해 주세요", e)
+                    UiStateError(context.getString(R.string.error_message_ui_state_error), e)
 
                 is IndexOutOfBoundsException ->
-                    UiIndexError("데이터를 불러오는 중 문제가 발생했습니다. 고객센터로 문의해 주세요", e)
+                    UiIndexError(context.getString(R.string.error_message_ui_index_error), e)
 
                 is SecurityException ->
-                    DeviceSecurityError("기기 접근 권한이 필요합니다. '설정'에서 기기 접근을 허용해 주세요", e)
+                    DeviceSecurityError(context.getString(R.string.error_message_device_security_error), e)
 
                 is CameraAccessException ->
-                    CameraAccessError("카메라를 사용할 수 없습니다. 실행 중인 다른 앱을 종료한 후, 다시 시도해 주세요", e)
+                    CameraAccessError(context.getString(R.string.error_message_camera_access_error), e)
 
                 is BufferOverflowException ->
-                    BufferOverflowError("출력 데이터가 너무 많아 프린터가 응답하지 않습니다. 잠시 후 다시 시도해 주세요", e)
+                    BufferOverflowError(context.getString(R.string.error_message_buffer_overflow_error), e)
 
                 is FileNotFoundException ->
-                    FileNotFoundError(null, e)
+                    FileNotFoundError(null, e)  // 사용자 알림 필요 없음
 
                 is IOException ->
-                    DeviceAccessError("연결할 기기를 찾을 수 없습니다. 고객센터로 문의해 주세요", e)
+                    DeviceAccessError(context.getString(R.string.error_message_device_access_error), e)
 
                 is OutOfMemoryError ->
-                    MemoryError("시스템 오류가 발생했습니다. 새로고침을 시도해 주세요", e)
+                    MemoryError(context.getString(R.string.error_message_memory_error), e)
 
-                else -> UnknownError("예상치 못한 오류가 발생했습니다. 새로고침을 시도해 주세요", e)
+                else -> UnknownError(context.getString(R.string.error_message_unknown_error), e)
             }
         }
 

--- a/presentation/src/main/java/com/example/presentation/state/UiState.kt
+++ b/presentation/src/main/java/com/example/presentation/state/UiState.kt
@@ -10,8 +10,8 @@ sealed class UiState<out T>(open val data: T? = null) {
     data object None : UiState<Nothing>()
     data object Loading : UiState<Nothing>()
     data class Error<out T>(
-        val message: String,
-        val error: Failure,
+        val message: String?,
+        val error: Failure?,
         override val data: T? = null
     ) : UiState<T>(data)
     data class Success<out T>(override val data: T) : UiState<T>(data)

--- a/presentation/src/main/java/com/example/presentation/util/ResourceProvider.kt
+++ b/presentation/src/main/java/com/example/presentation/util/ResourceProvider.kt
@@ -1,0 +1,5 @@
+package com.example.presentation.util
+
+interface ResourceProvider {
+    fun getString(resId: Int): String
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -6,4 +6,23 @@
     <string name="again_btn">다시하기</string>
     <string name="alert_error">에러가 발생했습니다!!</string>
     <string name="error_handling_btn">새로고침</string>
+
+    <!-- ErrorMessage: Failure -->
+    <string name="error_message_network_failure">네트워크 연결이 불안정합니다. 연결을 확인해 주세요</string>
+    <string name="error_message_server_failure">서버에서 오류가 발생했습니다. 잠시 후 다시 시도해 주세요</string>
+    <string name="error_message_database_failure">데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요</string>
+    <string name="error_message_business_failure">잘못된 접근입니다</string>
+    <string name="error_message_validation_failure">잘못된 입력값입니다</string>
+    <string name="error_message_app_crash_failure">시스템 오류가 발생했습니다. 새로고침을 시도해 주세요</string>
+    <string name="error_message_unknown_failure">알 수 없는 오류가 발생했습니다. 새로고침을 시도해 주세요</string>
+
+    <!-- ErrorMessage: UiException -->
+    <string name="error_message_ui_state_error">예상치 못한 오류가 발생했습니다. 새로고침을 시도해 주세요</string>
+    <string name="error_message_ui_index_error">데이터를 불러오는 중 문제가 발생했습니다. 고객센터로 문의해 주세요</string>
+    <string name="error_message_device_security_error">기기 접근 권한이 필요합니다. "'"설정"'"에서 기기 접근을 허용해 주세요</string>
+    <string name="error_message_camera_access_error">카메라를 사용할 수 없습니다. 실행 중인 다른 앱을 종료한 후, 다시 시도해 주세요</string>
+    <string name="error_message_buffer_overflow_error">출력 데이터가 너무 많아 프린터가 응답하지 않습니다. 잠시 후 다시 시도해 주세요</string>
+    <string name="error_message_device_access_error">연결할 기기를 찾을 수 없습니다. 고객센터로 문의해 주세요</string>
+    <string name="error_message_memory_error">시스템 오류가 발생했습니다. 새로고침을 시도해 주세요</string>
+    <string name="error_message_unknown_error">알 수 없는 오류가 발생했습니다. 새로고침을 시도해 주세요</string>
 </resources>


### PR DESCRIPTION
## ☝️연관된 이슈

<b>#11</b>

## ✌️구현 내용
ErrorLog 저장을 포함한 최종 ErrorHandling 로직 구현
- `presentation` 모듈
  - activity/fragment
    - 발생한 모든 Exception에 대해 `UiException`으로 처리한 후 `Failure`로 변환하여 viewmodel에 전달
  - viewmodel
    - `BaseViewModel`에서 `open fun mapFailureToUiState(failure: Failure)` 구현
      : `ErrorLog` 저장 및 failure 별 사용자 에러 메세지 반환
    - viewmodel에서 `mapFailureToUiState(failure: Failure)` 메소드를 override하여 `UiException`/`DataException`으로부터 생성된 모든 failure에 대해 처리
: UiState.Loading(Success) -> UiState.Error()
  - UiState 변화에 따라 activity/fragment에서 추가 이벤트 생성(dialog/snackbar 띄우기 등)
- `domain` 모듈, `data` 모듈은 #7 과 동일한 로직

## 👌리뷰 요구사항
.
